### PR TITLE
163 - fixed deep learning buttons

### DIFF
--- a/main.qml
+++ b/main.qml
@@ -5,6 +5,7 @@ import QtQuick.Dialogs
 
 
 ApplicationWindow {
+    property bool isRandomForestSelected: false
     visible: true
     width: 1200
     height: 800 
@@ -273,13 +274,12 @@ ApplicationWindow {
                             ColumnLayout {
                                 spacing: 5
                                 Layout.alignment: Qt.AlignHCenter
-
+                                
                                 // Radio Button
                                 RadioButton {
                                     id: randomForestRadio
                                     Layout.alignment: Qt.AlignHCenter
-                                    checked: true
-                                    onClicked: backend.selectModel("Random Forest")
+                                    checked: isRandomForestSelected
                                 }
 
                                 // Green Box with Text
@@ -296,6 +296,14 @@ ApplicationWindow {
                                         color: "white"
                                         anchors.centerIn: parent
                                     }
+
+                                    MouseArea {
+                                        anchors.fill: parent
+                                        onClicked: {
+                                            isRandomForestSelected = true;
+                                            backend.selectModel("Random Forest");
+                                        }
+                                    }
                                 }
                             }
                             ColumnLayout {
@@ -306,7 +314,7 @@ ApplicationWindow {
                                 RadioButton {
                                     id: deepLearningRadio
                                     Layout.alignment: Qt.AlignHCenter
-                                    onClicked: backend.selectModel("Deep Learning")
+                                    checked: !isRandomForestSelected
                                 }
                                 // Green Box with Text
                                 Rectangle {
@@ -320,6 +328,14 @@ ApplicationWindow {
                                         font.pixelSize: 16
                                         color: "white"
                                         anchors.centerIn: parent
+                                    }
+                                }
+
+                                MouseArea {
+                                    anchors.fill: parent
+                                    onClicked: {
+                                        isRandomForestSelected = false;
+                                        backend.selectModel("Deep Learning");
                                     }
                                 }
                             }


### PR DESCRIPTION
Group 8 - CSCI 310 

Associated with #163 

The deep learning buttons did not work before, as you can see in the following capture:
![Before](https://github.com/user-attachments/assets/8d0362ba-a9ed-458e-83ae-2ef57ea23c24)

Now they work, as you can see when the buttons are pressed:
![After](https://github.com/user-attachments/assets/f4b8b2d7-dd7a-470b-b788-afcecd57dbbd)

Additional contributor: @chavue91 
