### PR TITLE
Final working file shuffler for Issue #195 – uses CSV input only

### DIFF
--- a/file-shuffler/file-shuffler-gui.py
+++ b/file-shuffler/file-shuffler-gui.py
@@ -1,7 +1,7 @@
 # This Python file uses the following encoding: utf-8
 import sys
-import subprocess
 from pathlib import Path
+import pandas as pd
 
 from PySide6.QtCore import QObject, Slot
 from PySide6.QtGui import QGuiApplication
@@ -12,18 +12,56 @@ class FileShufflerGui(QObject):
     def __init__(self):
         super().__init__()
 
+    @Slot(str)
+    def shuffle_csv_file(self, file_path):
+        # Fix for file:/// prefix from QML
+        if file_path.startswith("file:///"):
+            file_path = file_path.replace("file:///", "")
+
+        print("Received file path:", file_path)
+
+        try:
+            if not file_path.endswith('.csv'):
+                print("Not a CSV file. Ignored.")
+                return
+
+            # Read the CSV file
+            df = pd.read_csv(file_path)
+            print("CSV file read. First few rows:")
+            print(df.head())
+
+            # Shuffle the data
+            shuffled_df = df.sample(frac=1).reset_index(drop=True)
+
+            # Save the shuffled file
+            output_path = file_path.replace(".csv", "_shuffled.csv")
+            shuffled_df.to_csv(output_path, index=False)
+
+            print(f"Shuffled CSV saved at: {output_path}")
+
+        except Exception as e:
+            print("Error processing CSV:", str(e))
+
+
 if __name__ == "__main__":
     app = QGuiApplication(sys.argv)
     engine = QQmlApplicationEngine()
 
-    engine.addImportPath(str(Path(__file__).resolve().parent)) #so that I can call the file shuffler view class from here
-
+    engine.addImportPath(str(Path(__file__).resolve().parent))
 
     bindingContext = FileShufflerGui()
     engine.rootContext().setContextProperty("fileShufflerGui", bindingContext)
 
     qml_file = Path(__file__).resolve().parent / "main.qml"
+    print("Trying to load QML from:", qml_file)
+
+    if not qml_file.exists():
+        print("ERROR: main.qml not found at path:", qml_file)
+        sys.exit(1)
+
     engine.load(qml_file)
     if not engine.rootObjects():
         sys.exit(-1)
+
     sys.exit(app.exec())
+

--- a/file-shuffler/main.qml
+++ b/file-shuffler/main.qml
@@ -7,17 +7,39 @@ ApplicationWindow {
     visible: true
     width: 640
     height: 480
-    color: "#4a5b7b" // Set the background color
+    color: "#4a5b7b"
     title: "File Shuffler"
 
-    Loader {
-        source: "./file-shuffler-component/file-shuffler-view.qml"
-        onStatusChanged: {
-            if (status === Loader.error) {
-                console.error("Error loading file-shuffler-view.qml:", source, errorString())
-            } else if (status === Loader.Ready) {
-                console.log("Successfully loaded file-shuffler-view.qml:")
+    ColumnLayout {
+        anchors.centerIn: parent
+        spacing: 20
+
+        Button {
+            text: "Select CSV File"
+            Layout.alignment: Qt.AlignHCenter
+            onClicked: fileDialog.open()
+        }
+
+        FileDialog {
+            id: fileDialog
+            title: "Choose a CSV file to shuffle"
+            nameFilters: ["CSV files (*.csv)"]
+            fileMode: FileDialog.OpenFile
+            visible: false
+
+            onAccepted: {
+                if (fileDialog.selectedFile) {
+                    console.log("File selected:", fileDialog.selectedFile)
+                    fileShufflerGui.shuffle_csv_file(fileDialog.selectedFile)
+                } else {
+                    console.log("No file returned")
+                }
+            }
+
+            onRejected: {
+                console.log("File dialog canceled")
             }
         }
     }
 }
+


### PR DESCRIPTION
This pull request resolve Issue #195. The original File shuffler was designed to convert .txt files to .csv, but this step is no longer necessary.
This update includes:
A new PySide6-based GUI to select .csv files
Direct reading and shuffling of .csv brainwave files using pandas
Saving the shuffled output as *_shuffled.csv in the same directory
Tested locally using .csv files from the brainwave dataset provided by the instructor. No errors were encountered.