### PR TITLE
UI Update: Made All Text Bold for Consistency Across Ta

### DIFF
--- a/GUI5_BrainwaveReading/GUI5_BrainwaveReading.qml
+++ b/GUI5_BrainwaveReading/GUI5_BrainwaveReading.qml
@@ -391,7 +391,7 @@ ApplicationWindow {
 
                                 Text {
                                     text: "Console Log"
-                                    font.bold: true
+                                    font.weight: Font.Bold
                                     font.pixelSize: 20
                                     color: "white"
                                     horizontalAlignment: Text.AlignHCenter

--- a/GUI5_BrainwaveReading/GUI5_BrainwaveReading.qml
+++ b/GUI5_BrainwaveReading/GUI5_BrainwaveReading.qml
@@ -390,7 +390,7 @@ ApplicationWindow {
                                 anchors.fill: parent
 
                                 Text {
-                                    text: "Console Log BOLD TEST"
+                                    text: "Console Log"
                                     font.weight: Font.Bold
                                     font.pixelSize: 20
                                     color: "white"

--- a/GUI5_BrainwaveReading/GUI5_BrainwaveReading.qml
+++ b/GUI5_BrainwaveReading/GUI5_BrainwaveReading.qml
@@ -390,7 +390,7 @@ ApplicationWindow {
                                 anchors.fill: parent
 
                                 Text {
-                                    text: "Console Log"
+                                    text: "Console Log BOLD TEST"
                                     font.weight: Font.Bold
                                     font.pixelSize: 20
                                     color: "white"

--- a/GUI5_BrainwaveReading/GUI5_BrainwaveReading.qml
+++ b/GUI5_BrainwaveReading/GUI5_BrainwaveReading.qml
@@ -241,6 +241,7 @@ ApplicationWindow {
                                 Text {
                                     text: "Flight Log"
                                     font.bold: true
+                                    font.pixelSize: 20
                                     color: "white"
                                     horizontalAlignment: Text.AlignHCenter
                                     Layout.alignment: Qt.AlignHCenter
@@ -308,13 +309,14 @@ ApplicationWindow {
                             Layout.preferredWidth: 700
                             Layout.preferredHeight: 550
                             
-                            ColumnLayout {
+                             ColumnLayout {
                                 spacing: 5
                                 anchors.fill: parent
 
                                 Text {
                                     text: "Predictions Table"
                                     font.bold: true
+                                    font.pixelSize: 20
                                     color: "white"
                                     horizontalAlignment: Text.AlignHCenter
                                     Layout.alignment: Qt.AlignHCenter
@@ -390,6 +392,7 @@ ApplicationWindow {
                                 Text {
                                     text: "Console Log"
                                     font.bold: true
+                                    font.pixelSize: 20
                                     color: "white"
                                     horizontalAlignment: Text.AlignHCenter
                                     Layout.alignment: Qt.AlignHCenter

--- a/GUI5_BrainwaveReading/GUI5_BrainwaveReading.qml
+++ b/GUI5_BrainwaveReading/GUI5_BrainwaveReading.qml
@@ -113,7 +113,7 @@ ApplicationWindow {
                         Label {
                             text: "The model says ..."
                             color: "white"
-                            
+                            font.bold: true
                             Layout.alignment: Qt.AlignHCenter
                         }
 
@@ -231,10 +231,21 @@ ApplicationWindow {
 
                         // Flight Log
                         GroupBox {
-                            title: "Flight Log"
                             Layout.preferredWidth: 230
                             Layout.preferredHeight: 170
                             
+                            ColumnLayout {
+                                spacing: 5
+                                anchors.fill: parent
+
+                                Text {
+                                    text: "Flight Log"
+                                    font.bold: true
+                                    color: "white"
+                                    horizontalAlignment: Text.AlignHCenter
+                                    Layout.alignment: Qt.AlignHCenter
+                                }
+
                             // Background Rectangle inside the ListView
                             Rectangle {
                                 color: "white"  // Set only the box area color to white
@@ -294,9 +305,21 @@ ApplicationWindow {
 
                         // Predictions Table
                         GroupBox {
-                            title: "Predictions Table"
                             Layout.preferredWidth: 700
                             Layout.preferredHeight: 550
+                            
+                            ColumnLayout {
+                                spacing: 5
+                                anchors.fill: parent
+
+                                Text {
+                                    text: "Predictions Table"
+                                    font.bold: true
+                                    color: "white"
+                                    horizontalAlignment: Text.AlignHCenter
+                                    Layout.alignment: Qt.AlignHCenter
+                                }
+
 
                             // Header with white background
                             RowLayout {
@@ -357,10 +380,21 @@ ApplicationWindow {
 
                         // Console Log
                         GroupBox {
-                            title: "Console Log"
                             Layout.preferredWidth: 230
                             Layout.preferredHeight: 170
                             
+                            ColumnLayout {
+                                spacing: 5
+                                anchors.fill: parent
+
+                                Text {
+                                    text: "Console Log"
+                                    font.bold: true
+                                    color: "white"
+                                    horizontalAlignment: Text.AlignHCenter
+                                    Layout.alignment: Qt.AlignHCenter
+                                }
+
                             // Background Rectangle inside the ListView
                             Rectangle {
                                 color: "white"  // Set only the box area color to white


### PR DESCRIPTION
This pull request addresses the UI/UX ticket requesting all interface text to be uniformly bold wherever applicable, particularly on dark/blue backgrounds.

✅ Updates Completed:
Ensured bold text styling across all relevant sections of the Brainwave Reading tab.

Titles like “Predictions Table”, “Console Log”, and “Flight Log” were modified to use a Text component with font.bold: true to ensure consistent rendering, rather than relying on GroupBox.title.

Styled "Manual Command" label area to match the white bold text style for visual harmony.

Verified that buttons like “Read my mind...”, “Execute”, “Connect”, and radio buttons (Manual Control, Autopilot) remain bold and consistent with the design.
![image](https://github.com/user-attachments/assets/2f6b6047-23f3-42c7-9b39-5a662bc32751)
