### PR TITLE
Removed radio buttons for Random Forest and Deep Learning (#268)

### DIFF
--- a/main.qml
+++ b/main.qml
@@ -299,12 +299,6 @@ ApplicationWindow {
                                 spacing: 5
                                 Layout.alignment: Qt.AlignHCenter
                                 
-                                // Radio Button
-                                RadioButton {
-                                    id: randomForestRadio
-                                    Layout.alignment: Qt.AlignHCenter
-                                    checked: isRandomForestSelected
-                                }
 
                                 // Green Box with Text
                                 Rectangle {
@@ -334,12 +328,7 @@ ApplicationWindow {
                                 spacing: 5
                                 Layout.alignment: Qt.AlignHCenter
 
-                                // Radio Button
-                                RadioButton {
-                                    id: deepLearningRadio
-                                    Layout.alignment: Qt.AlignHCenter
-                                    checked: !isRandomForestSelected
-                                }
+                                
                                 // Green Box with Text
                                 Rectangle {
                                     width: 150


### PR DESCRIPTION
#This PR resolves issue #268. It removes the redundant radio buttons for Random Forest and Deep Learning in `main.qml`. Visual feedback is already provided via button color state, making the radio buttons unnecessary.
