### PR TITLE
Add prediction endpoint container to k8s.yaml

### DIFF
--- a/server/devops/deployment/k8s.yaml
+++ b/server/devops/deployment/k8s.yaml
@@ -2,6 +2,7 @@
 # it into Kubernetes.
 #
 # Created with podman-3.4.4
+# Modified to include prediction endpoint container
 apiVersion: v1
 kind: Pod
 metadata:
@@ -20,7 +21,6 @@ spec:
           hostPort: 10000
         - containerPort: 80
           hostPort: 9000
-
       resources: {}
       securityContext:
         capabilities:
@@ -37,8 +37,27 @@ spec:
         - nginx
         - -g
         - daemon off;
+        - -c
+        - /etc/nginx/nginx.conf
       image: docker.io/library/nginx:latest
       name: nginx-pod
+      ports:
+        - containerPort: 80
+      resources: {}
+      securityContext:
+        capabilities:
+          drop:
+            - CAP_MKNOD
+            - CAP_NET_RAW
+            - CAP_AUDIT_WRITE
+      volumeMounts:
+        - mountPath: /etc/nginx/nginx.conf
+          name: nginx-config
+          subPath: nginx.conf
+    - image: docker.io/jdknuds/prediction:latest
+      name: prediction-pod
+      ports:
+        - containerPort: 5000
       resources: {}
       securityContext:
         capabilities:
@@ -64,4 +83,7 @@ spec:
     - name: notebook-pvc
       persistentVolumeClaim:
         claimName: notebook-pvc
+    - name: nginx-config
+      configMap:
+        name: nginx-config
 status: {}

--- a/server/devops/deployment/nginx-configmap.yaml
+++ b/server/devops/deployment/nginx-configmap.yaml
@@ -1,0 +1,48 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-config
+  labels:
+    app: 3C-SCSU-pod
+data:
+  nginx.conf: |
+    events {
+        worker_connections 1024;
+    }
+
+    http {
+        upstream prediction_service {
+            server 127.0.0.1:5000;
+        }
+
+        upstream jupyter_service {
+            server 127.0.0.1:8888;
+        }
+
+        server {
+            listen 80;
+            
+            # Default route - proxy to Jupyter
+            location / {
+                proxy_pass http://jupyter_service;
+                proxy_set_header Host $host;
+                proxy_set_header X-Real-IP $remote_addr;
+                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            }
+            
+            # Prediction endpoint routes
+            location /eegrandomforestprediction {
+                proxy_pass http://prediction_service/eegrandomforestprediction;
+                proxy_set_header Host $host;
+                proxy_set_header X-Real-IP $remote_addr;
+                proxy_set_header Content-Type application/json;
+            }
+            
+            location /lastprediction {
+                proxy_pass http://prediction_service/lastprediction;
+                proxy_set_header Host $host;
+                proxy_set_header X-Real-IP $remote_addr;
+            }
+        }
+    }
+

--- a/server/devops/nginx/nginx.conf
+++ b/server/devops/nginx/nginx.conf
@@ -1,0 +1,39 @@
+events {
+    worker_connections 1024;
+}
+
+http {
+    upstream prediction_service {
+        server 127.0.0.1:5000;
+    }
+
+    upstream jupyter_service {
+        server 127.0.0.1:8888;
+    }
+
+    server {
+        listen 80;
+        
+        # Default route - proxy to Jupyter
+        location / {
+            proxy_pass http://jupyter_service;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+        
+        # Prediction endpoint routes
+        location /eegrandomforestprediction {
+            proxy_pass http://prediction_service/eegrandomforestprediction;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header Content-Type application/json;
+        }
+        
+        location /lastprediction {
+            proxy_pass http://prediction_service/lastprediction;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
This PR adds the prediction endpoint container to the k8s.yaml file as requested in #36.

## Changes Made
- Added prediction container with port 5000 configuration to k8s.yaml
- Created nginx ConfigMap for reverse proxy routing
- Updated nginx container to use custom configuration 
- Configured routing for `/eegrandomforestprediction` and `/lastprediction` endpoints

## Files Modified/Added
- `server/devops/deployment/k8s.yaml` - Added prediction container and nginx config mount
- `server/devops/deployment/nginx-configmap.yaml` - New ConfigMap for nginx configuration
- `server/devops/nginx/nginx.conf` - Nginx reverse proxy configuration

## Implementation Notes
- Used `docker.io/jdknuds/prediction:latest` based on existing naming pattern
- Configured for production deployment with nginx reverse proxy
- All prediction requests routed through nginx to prediction service on port 5000
- Ready to address any feedback on Docker image reference or additional WSGI configuration if needed

## Testing
- YAML syntax validated
- All required components included per acceptance criteria



Closes #36