### PR TITLE
Added socket implementation of python2.7(naoqi) to python3(Avatar GUI)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ __pycache__/
 plotscode/plots/
 plotscode/.Rhistory
 plotscode/.RData
+
+pynaoqi-python2.7-2.8.6.23-linux64-20191127_152327/

--- a/GUI5.py
+++ b/GUI5.py
@@ -17,6 +17,7 @@ import contextlib
 from collections import defaultdict
 from brainflow.board_shim import BoardShim, BrainFlowInputParams, BoardIds
 from GUI5_ManualDroneControl.cameraview.camera_controller import CameraController
+from NAO6.nao_connection import send_command
 # from Developers.hofCharts import main as hofCharts, ticketsByDev_text
 
 from Developers import devCharts
@@ -68,9 +69,31 @@ class BrainwavesBackend(QObject):
 
     @Slot()
     def connectNao(self):
+        if send_command("connect"):
         # Mock function to simulate drone connection
-        self.flight_log.insert(0, "Nao connected.")
+            self.flight_log.insert(0, "Nao connected.")
+        else:
+            self.flight_log.insert(0, "Nao failed to connect.")
         self.flightLogUpdated.emit(self.flight_log)
+    
+    @Slot()
+    def nao_sit_down(self):
+        if send_command("sit_down"):
+            self.flight_log.insert(0, "Sitting down.")
+        else:
+            self.flight_log.insert(0, "Nao failed to sit.")
+        self.flightLogUpdated.emit(self.flight_log)
+    
+    @Slot()
+    def nao_stand_up(self):
+        if send_command("stand_up"):
+            self.flight_log.insert(0, "Standing Up.")
+        else:
+            self.fligt_log.insert(0, "Nao failed to stand up.")
+        self.flightLogUpdated.emit(self.flight_log)
+
+
+            
 
     @Slot(result=str)
     def getDevList(self):

--- a/ManualNaoControl.qml
+++ b/ManualNaoControl.qml
@@ -139,6 +139,12 @@ Rectangle {
                                                 if (typeof rootPanel[modelData.fn] === "function") {
                                                     rootPanel[modelData.fn]()
                                                 }
+                                                if (modelData.label == "Takeoff") {
+								                    backend.nao_stand_up()
+							                    }  else if (modelData.label == "Land") {
+                                                    backend.nao_sit_down()
+						                        }
+
                                             }
                                         }
                                     }

--- a/NAO6/nao_connection.py
+++ b/NAO6/nao_connection.py
@@ -1,0 +1,34 @@
+import socket
+
+NAO_IP = "192.168.23.53"
+PORT = 9559
+
+def send_command(command):
+    """
+    Sends a command to the Python 2.7 NAO service.
+    Supported commands: 'connect', 'sit_down', 'stand_up'
+    """
+    try:
+        print(f"[DEBUG] Attempting to send command: {command}")
+        client = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        client.settimeout(5.0)  # Add timeout
+        client.connect(('localhost', 5000))
+        print(f"[DEBUG] Connected to service")
+        
+        client.send(command.encode())
+        print(f"[DEBUG] Command sent")
+        
+        response = client.recv(1024).decode().strip()
+        print(f"[DEBUG] Received response: {response}")
+        client.close()
+        return response
+
+    except socket.timeout:
+        print(f"[ERROR] Connection timeout - is nao_service.py running?")
+        return None
+    except ConnectionRefusedError:
+        print(f"[ERROR] Connection refused - nao_service.py is NOT running on port 5000")
+        return None
+    except Exception as e:
+        print(f"[ERROR] Error sending command '{command}': {e}")
+        return None

--- a/NAO6/nao_service.py
+++ b/NAO6/nao_service.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python2.7
+
+from naoqi import ALProxy
+
+import socket
+import json
+# NAO robot settings
+NAO_IP = "192.168.23.53"
+PORT = 9559
+
+
+def connect_to_nao():
+    """Try to connect to the NAO robot"""
+    try:
+        # Try to create a connection to NAO
+        test_proxy = ALProxy("ALBehaviorManager", NAO_IP, PORT)
+        print ("Successfully connected to NAO!")
+        return True
+    except Exception as e:
+        print ("Failed to connect to NAO:", str(e))
+        return False
+
+
+def nao_sit_down():
+    # Behavior name
+    behavior_name = "sitdown-b3bee7/Sit down"
+
+    # Create proxy to ALBehaviorManager
+    try:
+        behavior_mng = ALProxy("ALBehaviorManager", NAO_IP, PORT)
+    except Exception as e:
+        print("Could not create proxy to ALBehaviorManager")
+        print("Error:", e)
+        exit(1)
+
+    # Check if behavior is installed
+    if behavior_mng.isBehaviorInstalled(behavior_name):
+        if behavior_mng.isBehaviorRunning(behavior_name):
+            print("Behavior is already running.")
+            return True
+        else:
+            print("Starting behavior:", behavior_name)
+            behavior_mng.startBehavior(behavior_name)
+            return True
+    else:
+        print("Behavior not found on robot.")
+
+    return False
+
+def nao_stand_up():
+    # Behavior name
+    behavior_name = "standup-80f5e5/Stand up"
+
+    # Create proxy to ALBehaviorManager
+    try:
+        behavior_mng = ALProxy("ALBehaviorManager", NAO_IP,PORT)
+    except Exception as e:
+        print("Could not create proxy to ALBehaviorManager")
+        print("Error:", e)
+        exit(1)
+
+    # Check if behavior is installed
+    if behavior_mng.isBehaviorInstalled(behavior_name):
+        if behavior_mng.isBehaviorRunning(behavior_name):
+            print("Behavior is already running.")
+            return True
+        else:
+            print("Starting behavior:", behavior_name)
+            behavior_mng.startBehavior(behavior_name)
+            return True
+    else:
+        print("Behavior not found on robot.")
+
+    return False
+
+def main():
+    print ("Starting NAO Connection Service...")
+    print ("Connecting to NAO at", NAO_IP, ":", PORT)
+    
+    # Create a socket to listen for connection requests
+    server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    server.bind(('localhost', 5000))
+    server.listen(1)
+    
+    print ("Service ready on port 5000")
+    print ("Waiting for connection request from GUI...")
+    
+    while True:
+        try:
+            # Wait for GUI to send a request
+            client, address = server.accept()
+            print("Received connection from", address)
+            data = client.recv(1024).strip().lower()
+            print("Received command:", data)
+
+
+            if data == "connect":
+            # Try to connect to NAO
+                success = connect_to_nao()
+            elif data == "sit_down":
+                success = nao_sit_down()
+            elif data == "stand_up":
+                success = nao_stand_up()
+            else:
+                print("Unknown command pressed: ", data)
+                success = False
+            # Send response back to GUI
+            response = "SUCCESS" if success else "FAILED"
+            
+            client.send(response)
+            client.close()
+            print ("Sent response:", response)
+            
+        except KeyboardInterrupt:
+            print ("\nShutting down service...")
+            break
+        except Exception as e:
+            print ("Error:", str(e))
+    
+    server.close()
+
+if __name__ == "__main__":
+    main()
+

--- a/NAO6/quick_setup.md
+++ b/NAO6/quick_setup.md
@@ -1,0 +1,130 @@
+# NAO Robot Quick Start
+
+## Setup (5 minutes)
+
+### 1. Install Python 2.7
+
+**Ubuntu/Debian:**
+```bash
+sudo apt install python2.7
+```
+
+**macOS:**
+```bash
+brew install python@2
+```
+
+**Windows:**
+- Download from [python.org](https://www.python.org/downloads/release/python-2718/)
+- Install to `C:\Python27`
+
+### 2. Download NAOqi SDK
+
+1. Get it from [SoftBank Robotics](https://www.aldebaran.com/en/support/nao-6/downloads-softwares)
+2. Extract to project root:
+   - Linux: `tar -xzf pynaoqi-*.tar.gz`
+   - Windows: Extract with 7-Zip
+
+Your folder structure should be:
+```
+Avatar/
+├── pynaoqi-python2.7-*/
+├── NA06_Manual_Control/
+├── run_nao.sh
+└── GUI5.py
+```
+
+### 3. Install Python 3 Requirements
+
+```bash
+python3 -m venv venv
+source venv/bin/activate  # Windows: venv\Scripts\activate
+pip install -r requirements.txt
+```
+
+## Running
+
+### 1. Configure NAO IP
+
+Edit `NA06_Manual_Control/nao_service.py`:
+```python
+NAO_IP = "192.168.1.100"  # Your NAO's IP address
+```
+
+**Find NAO's IP:** Press chest button → NAO will speak it
+
+### 2. Start NAO Service
+
+**Linux/Mac:**
+```bash
+./run_nao.sh
+```
+
+**Windows:**
+```cmd
+run_nao.bat
+```
+
+Keep this terminal running.
+
+### 3. Launch GUI (new terminal)
+
+```bash
+source venv/bin/activate  # Windows: venv\Scripts\activate
+python GUI5.py
+```
+
+### 4. Connect
+
+1. Go to **Manual NAO Control** tab
+2. Click **Connect**
+3. Check flight log for status
+
+## Troubleshooting
+
+| Problem | Solution |
+|---------|----------|
+| "Python 2.7 not found" | Install Python 2.7 (see step 1) |
+| "NAOqi SDK not found" | Extract SDK to project root |
+| "Connection timeout" | Make sure `run_nao.sh` is running |
+| "Cannot connect to NAO" | Verify NAO IP and network connection |
+| Port 5000 in use | Kill process: `lsof -ti:5000 \| xargs kill -9` |
+
+## Architecture
+
+```
+GUI (Python 3) ←→ NAO Service (Python 2.7) ←→ NAO Robot
+   localhost:5000              NAOqi SDK         192.168.x.x:9559
+```
+
+The NAO service bridges the Python 3 GUI with the legacy Python 2.7 NAOqi SDK.
+
+## Adding Commands
+
+**1. In `nao_service.py`:**
+```python
+elif command == "wave":
+    motion = ALProxy("ALMotion", NAO_IP, NAO_PORT)
+    # Your code here
+    return {"status": "success", "message": "NAO waved!"}
+```
+
+**2. In `GUI5.py`:**
+```python
+def waveNao(self):
+    result = send_command("wave")
+    self.log_message(result['message'])
+```
+
+**3. In your QML:**
+```qml
+Button {
+    text: "Wave"
+    onClicked: backend.waveNao()
+}
+```
+
+## Support
+
+- **NAOqi Docs:** http://doc.aldebaran.com/2-8/
+- **Issues:** GitHub Issues tab

--- a/run_nao.sh
+++ b/run_nao.sh
@@ -1,0 +1,127 @@
+#!/bin/bash
+
+# Universal NAO Service Launcher
+# Auto-detects paths - works for all team members
+
+set -e  # Exit on error
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+echo -e "${GREEN}=== NAO Service Launcher ===${NC}\n"
+
+# 1. Detect project root (where this script is located)
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+PROJECT_ROOT="$SCRIPT_DIR"
+
+echo "Project root: $PROJECT_ROOT"
+
+# 2. Find NAOqi SDK (auto-detect in project directory)
+NAOQI_SDK=""
+if [ -d "$PROJECT_ROOT"/pynaoqi-python2.7* ]; then
+    NAOQI_SDK=$(find "$PROJECT_ROOT" -maxdepth 1 -type d -name "pynaoqi-python2.7*" | head -n 1)
+elif [ -d "$PROJECT_ROOT/naoqi" ]; then
+    NAOQI_SDK="$PROJECT_ROOT/naoqi"
+elif [ ! -z "$NAOQI_HOME" ]; then
+    NAOQI_SDK="$NAOQI_HOME"
+else
+    echo -e "${RED}ERROR: NAOqi SDK not found!${NC}"
+    echo "Please either:"
+    echo "  1. Extract NAOqi SDK to project root, OR"
+    echo "  2. Set NAOQI_HOME environment variable"
+    echo ""
+    echo "Download from: https://www.aldebaran.com/en/support/nao-6/downloads-softwares"
+    exit 1
+fi
+
+echo -e "${GREEN}${NC} Found NAOqi SDK: $NAOQI_SDK"
+
+# 3. Find Python 2.7
+PYTHON27=""
+if command -v python2.7 &> /dev/null; then
+    PYTHON27=$(command -v python2.7)
+elif [ -f "/opt/python2.7/bin/python2.7" ]; then
+    PYTHON27="/opt/python2.7/bin/python2.7"
+elif [ -f "/usr/bin/python2.7" ]; then
+    PYTHON27="/usr/bin/python2.7"
+elif [ -f "/usr/local/bin/python2.7" ]; then
+    PYTHON27="/usr/local/bin/python2.7"
+elif command -v python2 &> /dev/null; then
+    VERSION=$(python2 --version 2>&1 | grep -oP '2\.7\.\d+' || echo "")
+    if [ ! -z "$VERSION" ]; then
+        PYTHON27=$(command -v python2)
+    fi
+else
+    echo -e "${RED}ERROR: Python 2.7 not found!${NC}"
+    echo "Install instructions:" 
+    echo "  Ubuntu/Debian: sudo apt install python2.7"
+    echo "  macOS:         brew install python@2"
+    exit 1
+fi
+
+echo -e "${GREEN}${NC} Found Python 2.7: $PYTHON27"
+
+# 4. Set environment variables
+export PYTHONPATH="$NAOQI_SDK/lib/python2.7/site-packages:$PYTHONPATH"
+export QI_SDK="$NAOQI_SDK"
+export LD_LIBRARY_PATH="$NAOQI_SDK/lib:$LD_LIBRARY_PATH"
+
+# 5. Verify NAO service file exists
+SERVICE_FILE="$PROJECT_ROOT/NAO6/nao_service.py"
+if [ ! -f "$SERVICE_FILE" ]; then
+    echo -e "${RED}ERROR: nao_service.py not found!${NC}"
+    echo "Expected location: $SERVICE_FILE"
+    echo "Current directory contents:"
+    ls -la "$PROJECT_ROOT"
+    exit 1
+fi
+
+echo -e "${GREEN}${NC} Found service file: $SERVICE_FILE"
+
+# 6. Check for required NAOqi files
+echo ""
+echo "Checking NAOqi installation..."
+if [ -f "$NAOQI_SDK/lib/python2.7/site-packages/_qi.so" ] || [ -f "$NAOQI_SDK/lib/python2.7/site-packages/qi.so" ]; then
+    echo -e "${GREEN}${NC} NAOqi binaries present"
+else
+    echo -e "${YELLOW}${NC}  Warning: NAOqi binaries not found (will attempt anyway)"
+fi
+
+# 7. Kill existing service on port 5000
+PORT=5000
+echo ""
+echo "Checking port $PORT..."
+if command -v lsof &> /dev/null; then
+    PID=$(lsof -ti:$PORT 2>/dev/null || echo "")
+    if [ ! -z "$PID" ]; then
+        echo -e "${YELLOW}${NC}  Killing existing service (PID: $PID)"
+        kill -9 $PID 2>/dev/null || true
+        sleep 1
+    fi
+elif command -v netstat &> /dev/null; then
+    PID=$(netstat -tulpn 2>/dev/null | grep ":$PORT" | awk '{print $7}' | cut -d'/' -f1 || echo "")
+    if [ ! -z "$PID" ]; then
+        echo -e "${YELLOW}${NC}  Killing existing service (PID: $PID)"
+        kill -9 $PID 2>/dev/null || true
+        sleep 1
+    fi
+fi
+
+# 8. Display configuration
+echo ""
+echo -e "${GREEN}Configuration:${NC}"
+echo "  NAO Service Port: $PORT"
+echo "  Python 2.7:       $PYTHON27"
+echo "  NAOqi SDK:        $NAOQI_SDK"
+echo "  Service Script:   $SERVICE_FILE"
+
+# 9. Start the service
+echo ""
+echo -e "${GREEN}Starting NAO service...${NC}"
+echo "Press Ctrl+C to stop"
+echo ""
+
+$PYTHON27 "$SERVICE_FILE"


### PR DESCRIPTION
# Ticket #367 — Sit / Stand via Installed Behaviors

### Summary  
Map Avatar GUI’s **Take Off** and **Landing** buttons to NAO’s installed sit/stand behaviors using `ALBehaviorManager`.

See `quick_setup.md` for setup.

---

### Implementation

- Add `"sitDownBehavior"` and `"standUpBehavior"` commands in `nao_service.py`.
- Use `ALBehaviorManager` to check and run behaviors.
- Connect GUI buttons in `GUI5.py` and QML to these commands.

---

### Testing

1. Setup per `quick_setup.md`
2. Connect GUI to NAO
3. Press buttons, confirm behaviors run and no errors appear.

---

### About `nao_connection.py`

Handles sending commands from the Python 3 GUI to the Python 2 NAO service via TCP socket on localhost:5000, with error handling and debug output.
