### PR TITLE
Revert "Add access_data.txt placeholder under file-opendata/brainwaves"

### DIFF
--- a/file-opendata/brainwaves/access_data.txt
+++ b/file-opendata/brainwaves/access_data.txt
@@ -1,2 +1,0 @@
-TBA. Coming soon: Open S3 Databucket
-Stay tuned for updates.


### PR DESCRIPTION
Reverts 3C-SCSU/Avatar#463

Problem:
on the main Avatar directory, it is showing as: file-opendata/brainwaves
<img width="332" height="168" alt="image" src="https://github.com/user-attachments/assets/4bfbf2f0-b9b2-4ab0-87b6-2e62ad6064a2" />
it should not do / show that. It should only show the file-opendata.
Maybe you have to do first a pull request with only the directory file-opendata. And then a separated second pull request creating the subdirectory
