### PR TITLE
Fix: Add JAX framework button to Read Brain tab (#578)

### DIFF
--- a/BrainwaveReading.qml
+++ b/BrainwaveReading.qml
@@ -429,13 +429,13 @@ Rectangle {
 
                 // PyTorch and TensorFlow Framework Buttons
                 Row {
-                    width: parent.width * 0.5
+                    width: parent.width * 0.7
                     height: parent.height * 0.3
                     spacing: height * 0.1
 
                     //PyTorch Button
                     Rectangle {
-                        width: parent.width * 0.5
+                        width: parent.width * 0.33
                         height: parent.height
                         color: "#6eb109"
                         radius: 5
@@ -460,7 +460,7 @@ Rectangle {
 
                     //TensorFlow Button
                     Rectangle {
-                        width: parent.width * 0.5
+                        width: parent.width * 0.33
                         height: parent.height
                         color: "#6eb109"
                         radius: 5
@@ -479,6 +479,30 @@ Rectangle {
                             onClicked: {
                                 currentFramework = "TensorFlow"
                                 backend.selectFramework("TensorFlow")
+                            }
+                        }
+                      }
+                      //JAX Button
+                    Rectangle {
+                        width: parent.width * 0.33
+                        height: parent.height
+                        color: "#6eb109"
+                        radius: 5
+                        border.color: currentFramework === "JAX" ? "yellow" : "#5a8c2b"
+                        border.width: currentFramework === "JAX" ? 3 : 1
+                        Text {
+                            text: "JAX"
+                            font.pixelSize: parent.width * 0.08
+                            font.bold: true
+                            color: currentFramework === "JAX" ? "yellow" : "white"
+                            anchors.centerIn: parent
+                        }
+
+                        MouseArea {
+                            anchors.fill: parent
+                            onClicked: {
+                                currentFramework = "JAX"
+                                backend.selectFramework("JAX")
                             }
                         }
                     }


### PR DESCRIPTION
This PR adds the missing JAX framework button to the Read Brain tab, allowing users to select JAX as their preferred AI framework alongside PyTorch and TensorFlow.

# Changes
- Refactored framework selection from boolean to string based property for better extensibility
- Added JAX button with proper styling and functionality  
- Updated button layout to accommodate three framework options (PyTorch, TensorFlow, JAX)
- All buttons correctly highlight when selected and communicate with backend via `backend.selectFramework()`

# Screenshot
The JAX button now appears alongside PyTorch and TensorFlow in the Read Brain tab.
<img width="3406" height="1970" alt="image" src="https://github.com/user-attachments/assets/29afea11-2e2b-463e-b342-351cc503c5c2" />



Closes #578