### PR TITLE
A.I. Tab: Evenly distributed layout for Deploy/Train buttons (#577)

### DIFF
--- a/ArtificialIntelligence.qml
+++ b/ArtificialIntelligence.qml
@@ -512,13 +512,10 @@ Rectangle {
                         }
                     }
 
-                    // Vertical buttons column: Deploy / Train
-                    ColumnLayout {
-                        spacing: 16
-                        Layout.preferredWidth: 160
-                        Layout.minimumWidth: root.minControlSize
-                        Layout.fillHeight: true
-                        Layout.alignment: Qt.AlignTop
+                    // Buttons under Success Rate
+                    RowLayout {
+                            Layout.alignment: Qt.AlignHCenter
+                            spacing: 24
 
                         // DEPLOY
                         Button {


### PR DESCRIPTION
Updated the A.I. tab layout so the circular Deploy and Train buttons are now positioned under the Success Rate section instead of on the right side. This makes the layout more evenly distributed while keeping the existing button behavior and styling unchanged.

Closes #577 