### PR TITLE
Fix #554: Resolve run.sh shebang incompatibility on macOS

### DIFF
--- a/file-shuffler/run.sh
+++ b/file-shuffler/run.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 # Authors: Brady Theisen
 
 TRUE_PATH="$1"


### PR DESCRIPTION
## Summary
Fixes #554 - Resolves the "run.sh: not found Bad substitution" error when clicking the Anonymize button in the File Shuffler tab.

## Problem
The `run.sh` script used a hardcoded shebang `#!/usr/bin/bash` which doesn't work on macOS where bash is located at `/bin/bash`, not `/usr/bin/bash`. This caused the script to fail with "run.sh: not found" error.

## Solution
Changed the shebang to `#!/usr/bin/env bash` which is the portable approach that works across different Unix like systems by finding bash in the PATH.

## Changes
- Modified `file-shuffler/run.sh`: Changed shebang from `#!/usr/bin/bash` to `#!/usr/bin/env bash`

## Testing
- Verified script syntax passes bash validation (`bash -n run.sh`)
- Confirmed bash-specific syntax (`[[` constructs) remains valid
- Solution is portable across macOS, Linux, and other Unix systems