### PR TITLE
Fix #583: Add GaussianNB button to Artificial Intelligence tab

### DIFF
--- a/ArtificialIntelligence.qml
+++ b/ArtificialIntelligence.qml
@@ -25,7 +25,7 @@ Rectangle {
 
     // Mode and model selection
     property string mode: "Deploy"                 // "Deploy" (default) | "Train"
-    property string currentModel: "Random Forest"  // "Random Forest" | "Deep Learning"
+    property string currentModel: "Random Forest"  // "Random Forest" | "GaussianNB" | "Deep Learning"
 
     // Deep Learning params (UI state only for now)
     property real   learningRate: 0.001
@@ -131,6 +131,42 @@ Rectangle {
                                         currentModel = "Random Forest"
                                         backend.selectModel("Random Forest")
                                         logToConsole("Model selected: Random Forest")
+                                    }
+                                }
+                            }
+                            // GaussianNB
+                            Rectangle {
+                                Layout.fillWidth: true
+                                Layout.minimumWidth: root.minControlSize
+                                Layout.minimumHeight: root.minControlSize
+                                Layout.maximumWidth: 260
+                                implicitWidth: Math.max(root.minControlSize,
+                                                        Math.min(root.width * 0.16, 260))
+                                implicitHeight: Math.max(root.minControlSize,
+                                                         Math.min(root.height * 0.08, 90))
+                                radius: 8
+                                color: "#2d7a4a"
+                                border.color: currentModel === "GaussianNB" ? "#439566" : "#2d7a4a"
+                                border.width: currentModel === "GaussianNB" ? 3 : 1
+
+                                Text {
+                                    anchors.centerIn: parent
+                                    text: "GaussianNB"
+                                    color: currentModel === "GaussianNB" ? "yellow" : "white"
+                                    font.bold: true
+                                    font.pixelSize: Math.max(10,
+                                                             Math.min(20, parent.height * 0.35))
+                                    horizontalAlignment: Text.AlignHCenter
+                                    verticalAlignment: Text.AlignVCenter
+                                    wrapMode: Text.NoWrap
+                                }
+
+                                MouseArea {
+                                    anchors.fill: parent
+                                    onClicked: {
+                                        currentModel = "GaussianNB"
+                                        backend.selectModel("GaussianNB")
+                                        logToConsole("Model selected: GaussianNB")
                                     }
                                 }
                             }


### PR DESCRIPTION
## Summary
Fixes #583. Adds the missing GaussianNB model selection button to the Artificial Intelligence tab's Machine Learning section.

## Problem
The GaussianNB model was available in the "Read Brain" tab but missing from the "Artificial Intelligence" tab, creating an inconsistency in the UI and preventing users from selecting this model in the AI settings.

## Solution
Added a GaussianNB button to the Machine Learning section, positioned between Random Forest and Deep Learning buttons with identical styling and behavior.

## Changes
- Modified `ArtificialIntelligence.qml`:
  - Added GaussianNB button Rectangle with MouseArea
  - Updated currentModel property comment to include GaussianNB
  - Button calls `backend.selectModel("GaussianNB")` on click
  - Logs selection to console

## Testing
- GaussianNB button is visible and selectable
- Clicking button logs "Model selected: GaussianNB" to console
- Button highlights with yellow text and border when selected
- Styling matches Random Forest and Deep Learning buttons exactly
- Functionality matches Read Brain tab implementation

## Screenshot
<img width="1316" height="906" alt="image" src="https://github.com/user-attachments/assets/8072af9a-61b7-4e12-b4a6-e17fe15b545c" />
