### PR TITLE
Fix ManualNaoControl.qml Console Log Issue 

### DIFF
--- a/ManualNaoControl.qml
+++ b/ManualNaoControl.qml
@@ -117,7 +117,8 @@ Rectangle {
                                 rowSpacing: 20
                                 Layout.alignment: Qt.AlignHCenter
                                 Layout.fillWidth: true
-                                Layout.preferredHeight: 400
+                                Layout.preferredHeight: 500 // Updated the Height to fix Overlap issues
+                                Layout.maximumHeight: 500  // Updated the Height to fix Overlap issues
 
                                 Repeater {
                                     model: [


### PR DESCRIPTION
The Pull Request is for Github Ticket : https://github.com/3C-SCSU/Avatar/issues/419 To Fix NAO Console Log from overlapping

I have been informed that the Console Log is getting Overlap when you start pressing buttons

Update the GridLayout section preferredHeight and maximumHeight.

Output 

In Maximize Window 

<img width="1191" height="802" alt="Image1" src="https://github.com/user-attachments/assets/f3c3f534-f80c-4be6-b32c-e462c10a90af" />

In Maximize Window 

<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/94aad07e-a31a-4615-971f-478d07754da5" />

