### PR TITLE
First Drone+BCI Deployment - Made brainwave logs scrollable

### DIFF
--- a/BrainwaveReading.qml
+++ b/BrainwaveReading.qml
@@ -612,26 +612,31 @@ Rectangle {
                 }
             }
 
-            // Console Log
             GroupBox {
                 title: "Console Log"
                 width: parent.width * 0.6
                 height: parent.height * 0.3
                 label: Text { 
-                    text: qsTr("Console Log"); font.bold: true; color: "white" 
+                    text: qsTr("Console Log"); 
+                    font.bold: true; 
+                    color: "white" 
                 }
 
-                TextArea {
-                    id: consoleLog
+                ScrollView {
                     anchors.fill: parent
-                    text: "Console output here..."
-                    font.pixelSize: parent.width * 0.03
-                    color: "black"
-                    background: Rectangle { 
-                        color: "white" 
+                    clip: true
+
+                    TextArea {
+                        id: consoleLog
+                        wrapMode: Text.WrapAnywhere
+                        readOnly: true
+                        font.pixelSize: parent.width * 0.03
+                        color: "black"
+                        background: Rectangle { color: "white" }
                     }
                 }
             }
+
         }
     }
 }


### PR DESCRIPTION
In the Read Brain tab, if you generate more logs than the amount that can fit in the console log screen, users are unable to scroll. I changed the QML to use a ScrollView control to contain the TextArea control, which allows us to scroll through logs as they're generated:
<img width="1203" height="834" alt="image" src="https://github.com/user-attachments/assets/12e7ec8f-6984-4c2f-a253-b45c031ccd7d" />
