### PR TITLE
First Drone+BCI Deployment - Added logic that prevents the drone from landing/going to sleep after 15 seconds

### DIFF
--- a/ManualDroneControl.qml
+++ b/ManualDroneControl.qml
@@ -650,7 +650,7 @@ Rectangle {
                                 anchors.fill: parent
                                 onEntered: parent.color = "white"
                                 onExited: parent.color = "#242c4d"
-                                onClicked: backend.doDroneTAction("takeoff")
+                                onClicked: backend.takeoff()
                             }
                         }
 


### PR DESCRIPTION
First Drone+BCI Deployment - Added logic that prevents the drone from going to sleep by using a pseudo watchdog (timer instance running in the background) to keep the drone active (in other words, preventing it from landing after 15 seconds). Timer is set on a 200ms interval to run GUI5.hover_loop. Also updated the QML to run a takeoff function to perform the takeoff logic.