### PR TITLE
Align AI Deploy/Train border color with active mode (576)

### DIFF
--- a/ArtificialIntelligence.qml
+++ b/ArtificialIntelligence.qml
@@ -518,14 +518,14 @@ Rectangle {
                                         GradientStop { position: 0; color: "#6aa5ff" }
                                         GradientStop { position: 1; color: "#2d53cc" }
                                     }
-                                    border.color: deployBtn.checked ? "yellow" : "#102a6b"
+                                    border.color: mode === "Deploy" ? "yellow" : "#102a6b"
                                     border.width: 2
                                 }
 
                                 contentItem: Text {
                                     anchors.centerIn: parent
                                     text: "Deploy"
-                                    color: "yellow"
+                                    color: mode === "Deploy" ? "yellow" : "white"
                                     font.bold: true
                                     font.pixelSize: Math.max(10,
                                                             Math.min(22, parent.height * 0.25))
@@ -560,14 +560,14 @@ Rectangle {
                                         GradientStop { position: 0; color: "#6aa5ff" }
                                         GradientStop { position: 1; color: "#2d53cc" }
                                     }
-                                    border.color: trainBtn.checked ? "yellow" : "#102a6b"
+                                    border.color: mode === "Train" ? "yellow" : "#102a6b"
                                     border.width: 2
                                 }
 
                                 contentItem: Text {
                                     anchors.centerIn: parent
                                     text: "Train"
-                                    color: "white"
+                                    color: mode === "Train" ? "yellow" : "white"
                                     font.bold: true
                                     font.pixelSize: Math.max(10,
                                                             Math.min(22, parent.height * 0.25))


### PR DESCRIPTION
I opened a new PR for #576 with a minimal fix.

- Kept the current AI tab layout.
- Only updated the Deploy/Train border and label colors to follow `mode` so the
  active button is the only one with a yellow border.
- No extra ids and no new layouts.

Tested locally – the AI tab loads correctly and the visual behavior matches the ticket description.

closes #576