### PR TITLE
Delete file-opendata/.gitkeep

### DIFF
--- a/file-opendata/.gitkeep
+++ b/file-opendata/.gitkeep
@@ -1,1 +1,0 @@
-# an header to keep the file path correct


### PR DESCRIPTION
Removing this placeholder file. The directory now includes the real files, so the .gitkeep is no longer required for maintaining the folder path.