### PR TITLE
Fix Tab Top Padding #647

### DIFF
--- a/ManualNaoControl.qml
+++ b/ManualNaoControl.qml
@@ -47,22 +47,6 @@ Rectangle {
     ColumnLayout {
         anchors.fill: parent
         spacing: 10
-
-        // Tab bar
-        TabBar {
-            id: tabBar
-            Layout.fillWidth: true
-            height: 40
-            TabButton {
-                font.bold: true
-                onClicked: {
-                    stackLayout.currentIndex = 3
-                    console.log("Manual Controller tab clicked")
-                    tabController.startNaoViewer()
-                }
-            }
-        }
-
         // Stack layout for different views
         StackLayout {
             id: stackLayout


### PR DESCRIPTION
## Fix: Remove excessive vertical spacing on Manual NAO Control tab

### Changes
- Removed unnecessary `TabBar` code block in QML file causing layout inconsistencies

### Issue
The `[ Manual NAO Control ]` tab displayed excessive top margin and double-spaced content gap compared to other tabs, breaking uniform tab bar alignment.

### Resolution
Removing the redundant TabBar declaration resolved both vertical spacing issues:
- Tab header now aligns properly with adjacent tabs
- Content area spacing is now consistent across all tabs

Fixes vertical layout inconsistencies in the Manual NAO Control interface.

Before:
<img width="1198" height="199" alt="image" src="https://github.com/user-attachments/assets/776bdb20-840f-4254-bad8-d59ed82eb868" />

After: 
<img width="1920" height="1062" alt="2025-12-06-001157_1920x1062_scrot" src="https://github.com/user-attachments/assets/80f0a8f8-4bb7-4249-94e0-25b58502af41" />
