### PR TITLE
Fix GNB model button highlight to match other models

### DIFF
--- a/ArtificialIntelligence.qml
+++ b/ArtificialIntelligence.qml
@@ -146,7 +146,7 @@ Rectangle {
                                                          Math.min(root.height * 0.08, 90))
                                 radius: 8
                                 color: "#2d7a4a"
-                                border.color: currentModel === "GaussianNB" ? "#439566" : "#2d7a4a"
+                                border.color: currentModel === "GaussianNB" ? "yellow" : "#2d7a4a"
                                 border.width: currentModel === "GaussianNB" ? 3 : 1
 
                                 Text {


### PR DESCRIPTION
This PR fixes issue #634 by making the Gaussian Naive Bayes (GNB) model
selection button visually consistent with other models.

Changes:
- Updated the GNB button border color to highlight in yellow when selected,
  matching Random Forest and Deep Learning behavior.

This improves UI consistency and usability.