### PR TITLE
Add training parameters UI for Gaussian Naive Bayes

### DIFF
--- a/ArtificialIntelligence.qml
+++ b/ArtificialIntelligence.qml
@@ -44,6 +44,8 @@ Rectangle {
     property int    rfMinSamplesLeaf: 1
     property string rfMaxFeatures: "auto"     // auto|sqrt|log2
     property string rfCriterion: "gini"       // gini|entropy
+    // GaussianNB params (UI state only for now)
+    property real gnbVarSmoothing: 1e-9
 
     // Derived
     property bool paramsEnabled: mode === "Train"
@@ -146,7 +148,7 @@ Rectangle {
                                                          Math.min(root.height * 0.08, 90))
                                 radius: 8
                                 color: "#2d7a4a"
-                                border.color: currentModel === "GaussianNB" ? "#439566" : "#2d7a4a"
+                                border.color: currentModel === "GaussianNB" ? "yellow" : "#2d7a4a"
                                 border.width: currentModel === "GaussianNB" ? 3 : 1
 
                                 Text {
@@ -993,7 +995,36 @@ Rectangle {
                             }
                         }
                     }
+                    // GAUSSIAN NB PARAMS ----------------------------------
+                    ColumnLayout {
+                        visible: currentModel === "GaussianNB"
+                        spacing: 6
+                        Layout.fillWidth: true
 
+                        RowLayout {
+                            Layout.fillWidth: true
+                            spacing: 4
+
+                            Text {
+                                text: "var_smoothing:"
+                                color: "white"
+                                Layout.preferredWidth: 120
+                                font.pixelSize: Math.max(10,
+                                    Math.min(16, root.height * 0.02))
+                            }
+
+                            TextField {
+                                text: gnbVarSmoothing.toString()
+                                onEditingFinished: {
+                                    var v = parseFloat(text)
+                                    if (!isNaN(v) && v > 0)
+                                        gnbVarSmoothing = v
+                                    text = gnbVarSmoothing.toString()
+                                }
+                                Layout.fillWidth: true
+                            }
+                        }
+                    }
                     Item { Layout.fillHeight: true } // spacer
                 }
             }


### PR DESCRIPTION
This PR addresses part of issue #634 by adding missing training parameters
for the Gaussian Naive Bayes (GNB) model.

Changes:
- Added UI state for GNB var_smoothing parameter
- Displayed GNB-specific training parameters when the model is selected

This improves usability and model configurability.