### PR TITLE
Feature #567: Add gradient design to interactive tab buttons

### DIFF
--- a/main.qml
+++ b/main.qml
@@ -25,6 +25,7 @@ ApplicationWindow {
             height: 40
 
             TabButton {
+                id: readBrainTab
                 // this tab shows page index 0
                 property int targetIndex: 0
 
@@ -34,14 +35,24 @@ ApplicationWindow {
 
                 background: Rectangle {
                   anchors.fill: parent
-                  color: stackLayout.currentIndex === parent.targetIndex ? "green" : "#242c4d"
-                  border.color: stackLayout.currentIndex === parent.targetIndex ? "yellow" : "transparent"
-                  border.width: stackLayout.currentIndex === parent.targetIndex ? 3 : 1
+                  gradient: Gradient {
+                    GradientStop {
+                      position: 0.0
+                      color: stackLayout.currentIndex === readBrainTab.targetIndex ? "#00cc44" : "#2a3456"
+                    }
+                    GradientStop {
+                      position: 1.0
+                      color: stackLayout.currentIndex === readBrainTab.targetIndex ? "#008833" : "#1a2440"
+                    }
+                  }
+                  border.color: stackLayout.currentIndex === readBrainTab.targetIndex ? "yellow" : "transparent"
+                  border.width: stackLayout.currentIndex === readBrainTab.targetIndex ? 3 : 1
+                  radius: 5
                 }
                 contentItem: Text {
                     text: parent.text
                     anchors.centerIn: parent
-                    color: stackLayout.currentIndex === parent.targetIndex ? "yellow" : "white"
+                    color: stackLayout.currentIndex === readBrainTab.targetIndex ? "yellow" : "white"
                     font.bold: true
                     horizontalAlignment: Text.AlignHCenter
                     verticalAlignment: Text.AlignVCenter
@@ -50,6 +61,7 @@ ApplicationWindow {
             }
 
             TabButton {
+                id: manualDroneTab
                 property int targetIndex: 2
 
                 text: "Manual Drone Control"
@@ -58,14 +70,24 @@ ApplicationWindow {
 
                 background: Rectangle {
                   anchors.fill: parent
-                  color: stackLayout.currentIndex === parent.targetIndex ? "green" : "#242c4d"
-                  border.color: stackLayout.currentIndex === parent.targetIndex ? "yellow" : "transparent"
-                  border.width: stackLayout.currentIndex === parent.targetIndex ? 3 : 1
+                  gradient: Gradient {
+                    GradientStop {
+                      position: 0.0
+                      color: stackLayout.currentIndex === manualDroneTab.targetIndex ? "#00cc44" : "#2a3456"
+                    }
+                    GradientStop {
+                      position: 1.0
+                      color: stackLayout.currentIndex === manualDroneTab.targetIndex ? "#008833" : "#1a2440"
+                    }
+                  }
+                  border.color: stackLayout.currentIndex === manualDroneTab.targetIndex ? "yellow" : "transparent"
+                  border.width: stackLayout.currentIndex === manualDroneTab.targetIndex ? 3 : 1
+                  radius: 5
                 }
                 contentItem: Text {
                     text: parent.text
                     anchors.centerIn: parent
-                    color: stackLayout.currentIndex === parent.targetIndex ? "yellow" : "white"
+                    color: stackLayout.currentIndex === manualDroneTab.targetIndex ? "yellow" : "white"
                     font.bold: true
                     horizontalAlignment: Text.AlignHCenter
                     verticalAlignment: Text.AlignVCenter
@@ -74,6 +96,7 @@ ApplicationWindow {
             }
 
             TabButton {
+                id: manualNaoTab
                 property int targetIndex: 3
 
                 text: "Manual NAO Control"
@@ -86,14 +109,24 @@ ApplicationWindow {
 
                 background: Rectangle {
                   anchors.fill: parent
-                  color: stackLayout.currentIndex === parent.targetIndex ? "green" : "#242c4d"
-                  border.color: stackLayout.currentIndex === parent.targetIndex ? "yellow" : "transparent"
-                  border.width: stackLayout.currentIndex === parent.targetIndex ? 3 : 1
+                  gradient: Gradient {
+                    GradientStop {
+                      position: 0.0
+                      color: stackLayout.currentIndex === manualNaoTab.targetIndex ? "#00cc44" : "#2a3456"
+                    }
+                    GradientStop {
+                      position: 1.0
+                      color: stackLayout.currentIndex === manualNaoTab.targetIndex ? "#008833" : "#1a2440"
+                    }
+                  }
+                  border.color: stackLayout.currentIndex === manualNaoTab.targetIndex ? "yellow" : "transparent"
+                  border.width: stackLayout.currentIndex === manualNaoTab.targetIndex ? 3 : 1
+                  radius: 5
                 }
                 contentItem: Text {
                     text: parent.text
                     anchors.centerIn: parent
-                    color: stackLayout.currentIndex === parent.targetIndex ? "yellow" : "white"
+                    color: stackLayout.currentIndex === manualNaoTab.targetIndex ? "yellow" : "white"
                     font.bold: true
                     horizontalAlignment: Text.AlignHCenter
                     verticalAlignment: Text.AlignVCenter
@@ -102,6 +135,7 @@ ApplicationWindow {
             }
 
             TabButton {
+                id: aiTab
                 property int targetIndex: 7
 
                 text: "Artificial Intelligence"
@@ -113,14 +147,24 @@ ApplicationWindow {
 
                 background: Rectangle {
                   anchors.fill: parent
-                  color: stackLayout.currentIndex === parent.targetIndex ? "green" : "#242c4d"
-                  border.color: stackLayout.currentIndex === parent.targetIndex ? "yellow" : "transparent"
-                  border.width: stackLayout.currentIndex === parent.targetIndex ? 3 : 1
+                  gradient: Gradient {
+                    GradientStop {
+                      position: 0.0
+                      color: stackLayout.currentIndex === aiTab.targetIndex ? "#00cc44" : "#2a3456"
+                    }
+                    GradientStop {
+                      position: 1.0
+                      color: stackLayout.currentIndex === aiTab.targetIndex ? "#008833" : "#1a2440"
+                    }
+                  }
+                  border.color: stackLayout.currentIndex === aiTab.targetIndex ? "yellow" : "transparent"
+                  border.width: stackLayout.currentIndex === aiTab.targetIndex ? 3 : 1
+                  radius: 5
                 }
                 contentItem: Text {
                     text: parent.text
                     anchors.centerIn: parent
-                    color: stackLayout.currentIndex === parent.targetIndex ? "yellow" : "white"
+                    color: stackLayout.currentIndex === aiTab.targetIndex ? "yellow" : "white"
                     font.bold: true
                     horizontalAlignment: Text.AlignHCenter
                     verticalAlignment: Text.AlignVCenter
@@ -153,6 +197,7 @@ ApplicationWindow {
             position: TabBar.Footer
 
             TabButton {
+                id: brainwaveVizTab
                 property int targetIndex: 1
 
                 text: "Brainwave Visualization"
@@ -161,14 +206,24 @@ ApplicationWindow {
 
                 background: Rectangle {
                   anchors.fill: parent
-                  color: stackLayout.currentIndex === parent.targetIndex ? "green" : "#242c4d"
-                  border.color: stackLayout.currentIndex === parent.targetIndex ? "yellow" : "transparent"
-                  border.width: stackLayout.currentIndex === parent.targetIndex ? 3 : 1
+                  gradient: Gradient {
+                    GradientStop {
+                      position: 0.0
+                      color: stackLayout.currentIndex === brainwaveVizTab.targetIndex ? "#00cc44" : "#2a3456"
+                    }
+                    GradientStop {
+                      position: 1.0
+                      color: stackLayout.currentIndex === brainwaveVizTab.targetIndex ? "#008833" : "#1a2440"
+                    }
+                  }
+                  border.color: stackLayout.currentIndex === brainwaveVizTab.targetIndex ? "yellow" : "transparent"
+                  border.width: stackLayout.currentIndex === brainwaveVizTab.targetIndex ? 3 : 1
+                  radius: 5
                 }
                 contentItem: Text {
                     text: parent.text
                     anchors.centerIn: parent
-                    color: stackLayout.currentIndex === parent.targetIndex ? "yellow" : "white"
+                    color: stackLayout.currentIndex === brainwaveVizTab.targetIndex ? "yellow" : "white"
                     font.bold: true
                     horizontalAlignment: Text.AlignHCenter
                     verticalAlignment: Text.AlignVCenter
@@ -177,6 +232,7 @@ ApplicationWindow {
             }
 
             TabButton {
+                id: shufflerTab
                 property int targetIndex: 4
 
                 text: "Shuffler"
@@ -185,14 +241,24 @@ ApplicationWindow {
 
                 background: Rectangle {
                   anchors.fill: parent
-                  color: stackLayout.currentIndex === parent.targetIndex ? "green" : "#242c4d"
-                  border.color: stackLayout.currentIndex === parent.targetIndex ? "yellow" : "transparent"
-                  border.width: stackLayout.currentIndex === parent.targetIndex ? 3 : 1
+                  gradient: Gradient {
+                    GradientStop {
+                      position: 0.0
+                      color: stackLayout.currentIndex === shufflerTab.targetIndex ? "#00cc44" : "#2a3456"
+                    }
+                    GradientStop {
+                      position: 1.0
+                      color: stackLayout.currentIndex === shufflerTab.targetIndex ? "#008833" : "#1a2440"
+                    }
+                  }
+                  border.color: stackLayout.currentIndex === shufflerTab.targetIndex ? "yellow" : "transparent"
+                  border.width: stackLayout.currentIndex === shufflerTab.targetIndex ? 3 : 1
+                  radius: 5
                 }
                 contentItem: Text {
                     text: parent.text
                     anchors.centerIn: parent
-                    color: stackLayout.currentIndex === parent.targetIndex ? "yellow" : "white"
+                    color: stackLayout.currentIndex === shufflerTab.targetIndex ? "yellow" : "white"
                     font.bold: true
                     horizontalAlignment: Text.AlignHCenter
                     verticalAlignment: Text.AlignVCenter
@@ -201,6 +267,7 @@ ApplicationWindow {
             }
 
             TabButton {
+                id: cloudTab
                 property int targetIndex: 5
 
                 text: "Cloud Computing" // Renamed Transfer Data to Cloud Computing 
@@ -209,14 +276,24 @@ ApplicationWindow {
 
                 background: Rectangle {
                   anchors.fill: parent
-                  color: stackLayout.currentIndex === parent.targetIndex ? "green" : "#242c4d"
-                  border.color: stackLayout.currentIndex === parent.targetIndex ? "yellow" : "transparent"
-                  border.width: stackLayout.currentIndex === parent.targetIndex ? 3 : 1
+                  gradient: Gradient {
+                    GradientStop {
+                      position: 0.0
+                      color: stackLayout.currentIndex === cloudTab.targetIndex ? "#00cc44" : "#2a3456"
+                    }
+                    GradientStop {
+                      position: 1.0
+                      color: stackLayout.currentIndex === cloudTab.targetIndex ? "#008833" : "#1a2440"
+                    }
+                  }
+                  border.color: stackLayout.currentIndex === cloudTab.targetIndex ? "yellow" : "transparent"
+                  border.width: stackLayout.currentIndex === cloudTab.targetIndex ? 3 : 1
+                  radius: 5
                 }
                 contentItem: Text {
                     text: parent.text
                     anchors.centerIn: parent
-                    color: stackLayout.currentIndex === parent.targetIndex ? "yellow" : "white"
+                    color: stackLayout.currentIndex === cloudTab.targetIndex ? "yellow" : "white"
                     font.bold: true
                     horizontalAlignment: Text.AlignHCenter
                     verticalAlignment: Text.AlignVCenter
@@ -225,6 +302,7 @@ ApplicationWindow {
             }
 
             TabButton {
+                id: developersTab
                 property int targetIndex: 6
 
                 text: "Developers"
@@ -233,14 +311,24 @@ ApplicationWindow {
 
                 background: Rectangle {
                   anchors.fill: parent
-                  color: stackLayout.currentIndex === parent.targetIndex ? "green" : "#242c4d"
-                  border.color: stackLayout.currentIndex === parent.targetIndex ? "yellow" : "transparent"
-                  border.width: stackLayout.currentIndex === parent.targetIndex ? 3 : 1
+                  gradient: Gradient {
+                    GradientStop {
+                      position: 0.0
+                      color: stackLayout.currentIndex === developersTab.targetIndex ? "#00cc44" : "#2a3456"
+                    }
+                    GradientStop {
+                      position: 1.0
+                      color: stackLayout.currentIndex === developersTab.targetIndex ? "#008833" : "#1a2440"
+                    }
+                  }
+                  border.color: stackLayout.currentIndex === developersTab.targetIndex ? "yellow" : "transparent"
+                  border.width: stackLayout.currentIndex === developersTab.targetIndex ? 3 : 1
+                  radius: 5
                 }
                 contentItem: Text {
                     text: parent.text
                     anchors.centerIn: parent
-                    color: stackLayout.currentIndex === parent.targetIndex ? "yellow" : "white"
+                    color: stackLayout.currentIndex === developersTab.targetIndex ? "yellow" : "white"
                     font.bold: true
                     horizontalAlignment: Text.AlignHCenter
                     verticalAlignment: Text.AlignVCenter


### PR DESCRIPTION
## Issue
Closes #567

## Summary
This PR implements vertical gradient designs for all interactive tab buttons in the main navigation, replacing the previous flat color scheme with modern gradients that enhance visual hierarchy and user experience.

## Changes
- Replaced flat background colors with vertical gradients on all 8 tab buttons
- Added unique IDs to each TabButton for proper gradient referencing
- Active tabs: Bright to dark green gradient with yellow border
- Inactive tabs: Subtle blue gradient for visual depth
- Added 5px border radius for modern polished appearance

## Visual Design

**Active Tab Gradient:**
- Top: #00cc44 (bright green)
- Bottom: #008833 (darker green)
- Border: Yellow 3px (maintained from original design)

**Inactive Tab Gradient:**
- Top: #2a3456 (lighter blue)
- Bottom: #1a2440 (darker blue)
- Border: Transparent

## Implementation Details
- Modified all TabButton backgrounds in main.qml
- Used QML Gradient component with GradientStop positions
- Added unique IDs to prevent QML parent scope issues: readBrainTab, manualDroneTab, manualNaoTab, aiTab, brainwaveVizTab, shufflerTab, cloudTab, developersTab
- Maintained all existing tab functionality and event handlers
- No breaking changes to tab switching logic

## Testing
- Tested all 8 navigation tabs (4 top, 4 bottom)
- Verified gradient rendering and visual appearance
- Confirmed smooth tab switching functionality
- No QML errors or warnings
- Application performance maintained
- All existing features preserved

## Files Modified
- main.qml (tab button styling and structure)

<img width="1200" height="826" alt="Screenshot 2026-01-14 at 1 29 28 PM" src="https://github.com/user-attachments/assets/c27578e7-61f2-4101-ab81-9558d8afc767" />

--- 


<img width="1200" height="825" alt="Screenshot 2026-01-14 at 1 29 58 PM" src="https://github.com/user-attachments/assets/e752d4d9-65cb-4a59-b901-c7b34b4e6285" />
