### PR TITLE
fix #702: sync List of Developers with GitHub contributor charts

### DIFF
--- a/Developers.qml
+++ b/Developers.qml
@@ -236,9 +236,16 @@ Rectangle {
                 }
 
                 Component.onCompleted: {
-                    devText.text = developersBackend.getDevList()
+                    devText.text = "Loading..."
                     ticketText.text = developersBackend.getTicketsByDev()
                     developersBackend.devChart()
+                }
+
+                Connections {
+                    target: developersBackend
+                    function onPathsChanged() {
+                        devText.text = developersBackend.devListText
+                    }
                 }
             }
 
@@ -295,7 +302,7 @@ Rectangle {
                         }
 
                         onClicked: {
-                            devText.text = developersBackend.getDevList()
+                            devText.text = "Loading..."
                             ticketText.text = developersBackend.getTicketsByDev()
                             developersBackend.devChart()
                         }

--- a/developers_api.py
+++ b/developers_api.py
@@ -13,6 +13,7 @@ class DevelopersAPI(QObject):
         self._silver_path = ""
         self._bronze_path = ""
         self._medal_path = ""
+        self._dev_list_text = "Loading..."
         # Initialize paths on startup
         self.devImagePath()
 
@@ -28,12 +29,29 @@ class DevelopersAPI(QObject):
     def devChart(self):
         print("Generating charts...")
         try:
-            # 1. Run the generation logic from devCharts.py
-            devCharts.main() 
-            
-            # 2. Update paths with new timestamps and notify QML
+            # 1. Fetch GitHub contributor data once — used for both the list and the charts
+            data = devCharts.fetch_contributors_from_github()
+
+            if data:
+                # Build the dev list text from the same data the charts will use
+                lines = [f"{commits:>6}  {login}" for login, commits in data]
+                self._dev_list_text = "\n".join(lines)
+
+                # Generate the tier charts
+                base_dir = os.path.dirname(os.path.abspath(__file__))
+                plots_dir = os.path.join(base_dir, "Developers", "plotDevelopers")
+                os.makedirs(plots_dir, exist_ok=True)
+                tiered = devCharts.assign_fixed_tiers(data)
+                for tier in ["Gold", "Silver", "Bronze"]:
+                    chart_path = os.path.join(plots_dir, f"{tier.lower()}_contributors.png")
+                    devCharts.plot_single_tier(tiered, tier, chart_path)
+            else:
+                # Fallback: GitHub API unavailable — use local git shortlog
+                self._dev_list_text = devCharts.devList()
+
+            # 2. Update image paths with new timestamps and notify QML
             self.devImagePath()
-            self.pathsChanged.emit() 
+            self.pathsChanged.emit()
             print("Charts generated and QML notified.")
         except Exception as e:
             print(f"Error generating charts: {e}")
@@ -43,10 +61,10 @@ class DevelopersAPI(QObject):
         base_dir = os.path.dirname(os.path.abspath(__file__))
         # Point to the Developers/plotDevelopers subfolder
         plots_dir = os.path.join(base_dir, "Developers", "plotDevelopers")
-        
+
         # Unique timestamp forces QML to bypass its image cache
         timestamp = int(time.time())
-        
+
         def format_path(filename):
             full_p = os.path.abspath(os.path.join(plots_dir, filename)).replace("\\", "/")
             # Use file:/// for QML local file access
@@ -58,6 +76,10 @@ class DevelopersAPI(QObject):
         self._medal_path = format_path("Medal.png")
 
     # Properties with 'notify' decorators so QML updates automatically
+    @Property(str, notify=pathsChanged)
+    def devListText(self):
+        return self._dev_list_text
+
     @Property(str, notify=pathsChanged)
     def goldPath(self):
         return self._gold_path


### PR DESCRIPTION
## Problem

The **List of Developers** panel still showed incorrect data, git author names with emails instead of GitHub logins, and the top contributor was missing entirely. The Gold/Silver/Bronze charts were correct.

## Root Cause 

`Component.onCompleted` in `Developers.qml` called `getDevList()` **before** `devChart()`:

```
getDevList()   ← called first; GitHub stats API not ready yet → falls back to git shortlog
getTicketsByDev()
devChart()     ← called last; by now GitHub API has computed → charts are correct
```

This meant the list and the charts were always pulling from **different data sources**.

## Fix

**`developers_api.py`**
- `devChart()` now calls `fetch_contributors_from_github()` once and uses that data for **both** the contributor charts and the dev list text
- The formatted list is stored in `self._dev_list_text`
- A new `devListText` property (with `notify=pathsChanged`) exposes it to QML
- Fallback: if the GitHub API returns nothing, `devList()` (local git shortlog) is used

**`Developers.qml`**
- `Component.onCompleted` sets `devText.text = "Loading..."` instead of calling `getDevList()`
- A `Connections` block on `developersBackend` listens for `pathsChanged` and updates `devText.text = developersBackend.devListText`
- The Refresh button also sets `"Loading..."` so it re-syncs cleanly on each refresh

## Result

Single GitHub API fetch inside `devChart()` → same data used for both charts and list → List of Developers always matches https://github.com/3C-SCSU/Avatar/graphs/contributors

Closes #702